### PR TITLE
Update Thai translation URL

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -3,6 +3,6 @@
 Some unofficial translations are available courtesy of the community.
 
 - Chinese: [1](https://eddiewen.gitbooks.io/rscss/content/), [2](https://github.com/suhaotian/rscss-zh-cn)
-- [Thai](http://rscss.in.th/)
+- [Thai](https://rscss.apirak.com/)
 - [Japanese](http://qiita.com/kk6/items/760efba180ec526903db)
 - [Spanish](https://github.com/jameskolce/rscss-es)


### PR DESCRIPTION
- This PR is about updating Thai translation URL to a new URL.
- Thai translation URL has been changed to https://rscss.apirak.com/ and http://rscss.in.th/ does no longer exist
