### PR TITLE
Clarity a reason of using dash prefix for a variant

### DIFF
--- a/docs/variants.md
+++ b/docs/variants.md
@@ -28,11 +28,11 @@ Elements may also have variants.
   ```
 
 ## Dash prefixes
-Dashes are the preferred prefix for variants.
+A dash is the preferred prefix for a variant because:
 
   * It prevents ambiguity with elements.
-  * A CSS class can only start with a letter, `_` or `-`.
-  * Dashes are easier to type than underscores.
+  * A CSS class name can only start with a letter, `_` or `-`.
+  * A dash is easier to type than an underscore.
   * It kind of resembles switches in UNIX commands (`gcc -O2 -Wall -emit-last`).
 
 How do you deal with complex elements? Nest them.


### PR DESCRIPTION
IMHO, the existing document in [dash prefixes](https://rscss.io/variants.html#dash-prefixes) section makes me think if we can use an underscore to prefix a variant.

Especially "A CSS class can only start with a letter, _ or -." which makes me think "A variant class name can only start with a letter _ or -".

Actually, this section is about explaining a reason why we use a dash to prefix a variant.
Therefore, I have made this PR to clarify it.

FYI, this confusion made me create [this issue](https://github.com/rstacruz/rscss/issues/81) even though we know exactly that a variant must start with a dash `-`.

Thanks.

